### PR TITLE
Stable function traces

### DIFF
--- a/cao-lang/src/compiled_program.rs
+++ b/cao-lang/src/compiled_program.rs
@@ -75,10 +75,16 @@ impl CaoCompiledProgram {
 
     pub fn print_disassembly(&self) {
         let mut out = std::io::BufWriter::new(std::io::stdout());
-        self.disassemble(&mut out).unwrap();
+        self.disassemble_writer(&mut out).unwrap();
     }
 
-    pub fn disassemble(&self, mut writer: impl std::io::Write) -> std::io::Result<()> {
+    pub fn disassemble_string(&self) -> String {
+        let mut out = Vec::new();
+        self.disassemble_writer(&mut out).unwrap();
+        String::from_utf8(out).unwrap()
+    }
+
+    pub fn disassemble_writer(&self, mut writer: impl std::io::Write) -> std::io::Result<()> {
         let mut i = 0;
         while i < self.bytecode.len() {
             let instr: u8 = self.bytecode[i];

--- a/cao-lang/src/compiler/function_ir.rs
+++ b/cao-lang/src/compiler/function_ir.rs
@@ -6,6 +6,8 @@ use crate::VarName;
 /// Intermediate function data
 #[derive(Debug, Clone)]
 pub struct FunctionIr {
+    /// function's index in the context of its namespace
+    pub function_index: usize,
     pub name: Box<str>,
     pub arguments: Box<[VarName]>,
     pub cards: Box<[Card]>,
@@ -14,4 +16,14 @@ pub struct FunctionIr {
     ///
     /// TODO: we should compile modules instead of functions, and pass import per module...
     pub imports: Rc<ImportsIr>,
+    pub handle: crate::prelude::Handle,
+}
+
+impl FunctionIr {
+    pub fn full_name(&self) -> String {
+        if self.namespace.is_empty() {
+            return self.name.to_string();
+        }
+        format!("{}.{}", self.namespace.join("."), self.name)
+    }
 }

--- a/cao-lang/src/stdlib/tests.rs
+++ b/cao-lang/src/stdlib/tests.rs
@@ -206,8 +206,6 @@ fn min_test() {
             .as_table()
             .expect("table");
 
-        dbg!(t);
-        dbg!(t.get(&t.nth_key(0)));
     }
 
     let result = vm
@@ -215,7 +213,6 @@ fn min_test() {
         .unwrap();
     unsafe {
         let t = result.as_table().expect("table");
-        dbg!(t);
         match t.get("value").expect("value") {
             Value::Integer(i) => {
                 assert_eq!(*i, 10);
@@ -348,7 +345,6 @@ fn min_by_key_test() {
         .read_var_by_name("g_result", &compiled.variables)
         .unwrap();
     unsafe {
-        dbg!(result);
         let t = result.as_table().expect("table");
         match t.get("value").unwrap() {
             Value::Integer(i) => {

--- a/cao-lang/tests/integration_tests.rs
+++ b/cao-lang/tests/integration_tests.rs
@@ -537,7 +537,6 @@ fn jump_function_w_params_test() {
     let bar = vm
         .read_var_by_name("g_bar", &program.variables)
         .expect("Failed to read bar variable");
-    dbg!(foo, bar);
     assert!(matches!(foo, Value::Integer(42)));
     match bar {
         Value::Object(s) => unsafe {
@@ -703,7 +702,6 @@ fn non_existent_import_is_error_test() {
     let err = compile(cu, CompileOptions::new()).expect_err("compile");
 
     // TODO: the error itself should be more meaningful
-    dbg!(&err);
     assert!(matches!(
         err.payload,
         CompilationErrorPayload::InvalidJump { .. }
@@ -1284,7 +1282,6 @@ fn closure_test() {
         .read_var_by_name("g_result", &program.variables)
         .expect("Failed to read g_result variable");
 
-    dbg!(result);
 
     unsafe {
         let result = result.as_str().unwrap();
@@ -1345,7 +1342,6 @@ fn native_functions_can_call_cao_lang_function() {
     }
 
     let fun = move |vm: &mut Vm<State>, arg: Value| {
-        dbg!(vm.get_aux().res);
         let res = vm.run_function(arg)?;
         vm.get_aux_mut().res = res.as_int().unwrap();
         Ok(Value::Nil)

--- a/justfile
+++ b/justfile
@@ -21,3 +21,4 @@ build:
 	just wasm/build
 	python -m build --wheel
 
+alias t := test


### PR DESCRIPTION
Previously, the trace in the compile errors were incorrect due to the namespacing and the fact that we reorder function, so `main` comes first.